### PR TITLE
Added missing canonical URL to avoid duplicate content indexing

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,6 +5,7 @@
 {{ if or (eq site.BaseURL "/") (eq site.BaseURL "http://localhost:1313/") (eq site.BaseURL "http://examplesite.org/") (eq site.BaseURL "https://examplesite.org/") (eq site.BaseURL "http://examplesite.com/") (eq site.BaseURL "https://examplesite.com/")}}{{else}}
 <base href="{{ site.BaseURL }}">
 {{ end }}
+<link rel="canonical" href="{{ .Permalink }}" itemprop="url" />
 
 <!-- multilingual SEO optimizations -->
 {{ if .IsTranslated }}


### PR DESCRIPTION
Added missing canonical URL to avoid duplicate content indexing by search engines.

Reference : https://moz.com/learn/seo/canonicalization